### PR TITLE
[2201.0.1] Remove client class

### DIFF
--- a/cdata.bal
+++ b/cdata.bal
@@ -18,8 +18,3 @@
 // We need to add at least one .bal file to build the module.
 
 import ballerina/jballerina.java as _;
-
-@display {label: "CData Connect Driver", iconPath: "icon.png"}
-public isolated client class Client {
-
-}


### PR DESCRIPTION
## Purpose
> 
Currently the CData connect driver is visible as a connector in Choreo marketplace.

![Screenshot from 2022-03-25 16-43-19](https://user-images.githubusercontent.com/44081958/160110927-bec39c42-2b1f-403a-864a-88a541b5c7fb.png)

This is because the usage of a client class in the driver module. This PR removes the client class from the driver module.

Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/342

## Goals
> Remove client class to avoid detecting the driver module as a connector in Choreo marketplace.

## Approach
> Remove client class from driver module

## Release note
> Remove client class from driver module

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11